### PR TITLE
feat: remove old hack token at each start

### DIFF
--- a/dcli/utils/run-hack.sh
+++ b/dcli/utils/run-hack.sh
@@ -13,6 +13,9 @@ eval $(parse_yaml "$(pwd)/challenge.yaml" "challenge_")
 if [[ ! -e $DEADLOCK_TOKEN_TMP ]]; then
     echo "> create tmp dir.."
     mkdir -p $DEADLOCK_TOKEN_TMP
+else
+    echo "> remove old token.."
+    rm $DEADLOCK_TOKEN_TMP/*
 fi
 echo "> create tmp token.."
 echo $(uuidgen) > $DEADLOCK_TOKEN_TMP/$CANDIDATE_ID.token


### PR DESCRIPTION
Clean deadlock tmp directory at each start of a hack challenge.